### PR TITLE
corrections to validation status upload to minio

### DIFF
--- a/app/tasks/validation_tasks.py
+++ b/app/tasks/validation_tasks.py
@@ -100,7 +100,6 @@ def perform_ro_crate_validation(
             file_path,
         )
         settings = services.ValidationSettings(
-            data_path=full_file_path,
             rocrate_uri=full_file_path,
             # Only include profile_identifier if the profile_name is provided:
             **({"profile_identifier": profile_name} if profile_name else {}),

--- a/app/utils/minio_utils.py
+++ b/app/utils/minio_utils.py
@@ -81,8 +81,8 @@ def update_validation_status_in_minio(crate_id: str, validation_status: str) -> 
         # The object in MinIO is <crate_id>/validation_status.txt
         object_name = f"{crate_id}/validation_status.txt"
         
-        # convert to utf-8 encoded string
-        validation_string = json.dumps(validation_status).encode("utf-8")
+        # convert pretty string to dictionary, then back to plain utf-8 encoded string
+        validation_string = json.dumps(json.loads(validation_status), indent=None).encode("utf-8")
 
         minio_client.put_object(
             bucket_name,

--- a/app/utils/minio_utils.py
+++ b/app/utils/minio_utils.py
@@ -80,12 +80,15 @@ def update_validation_status_in_minio(crate_id: str, validation_status: str) -> 
 
         # The object in MinIO is <crate_id>/validation_status.txt
         object_name = f"{crate_id}/validation_status.txt"
+        
+        # convert to utf-8 encoded string
+        validation_string = json.dumps(validation_status).encode("utf-8")
 
         minio_client.put_object(
             bucket_name,
             object_name,
-            data=BytesIO(json.dumps(validation_status).encode("utf-8")),
-            length=len(validation_status.encode("utf-8")),
+            data=BytesIO(validation_string),
+            length=len(validation_string),
             content_type="application/json",
         )
 


### PR DESCRIPTION
Removing the `data_path` named variable from the ValidationSettings call because this variable was renamed `rocrate_uri` in commit https://github.com/crs4/rocrate-validator/commit/f62a8ae0a083113f3175f36cd289f531c7a1c5b1