### PR TITLE
Api get validation result

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,11 @@ app/
 ## Example Usage
 
 ```
-curl -X POST http://localhost:5001/ro_crates/post/validate_by_id_no_webhook -d "id=1"
+curl -X 'POST' \
+  'http://localhost:5001/ro_crates/validate_by_id_no_webhook' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "crate_id": "1"
+}'
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,20 +6,20 @@
 
 import os
 
-from flask import Flask
+from apiflask import APIFlask
 
 from app.celery_worker import make_celery, celery
 from app.ro_crates.routes import ro_crates_bp
 from app.utils.config import DevelopmentConfig, ProductionConfig, make_celery
 
 
-def create_app() -> Flask:
+def create_app() -> APIFlask:
     """
     Creates and configures Flask application.
 
     :return: Flask: A configured Flask application instance.
     """
-    app = Flask(__name__)
+    app = APIFlask(__name__)
     app.register_blueprint(ro_crates_bp, url_prefix="/ro_crates")
 
     # Load configuration:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,7 @@ import os
 from apiflask import APIFlask
 
 from app.celery_worker import make_celery, celery
-from app.ro_crates.routes import ro_crates_bp
+from app.ro_crates.routes import ro_crates_post_bp, ro_crates_get_bp
 from app.utils.config import DevelopmentConfig, ProductionConfig, make_celery
 
 
@@ -20,7 +20,8 @@ def create_app() -> APIFlask:
     :return: Flask: A configured Flask application instance.
     """
     app = APIFlask(__name__)
-    app.register_blueprint(ro_crates_bp, url_prefix="/ro_crates")
+    app.register_blueprint(ro_crates_post_bp, url_prefix="/ro_crates")
+    app.register_blueprint(ro_crates_get_bp, url_prefix="/ro_crates")
 
     # Load configuration:
     if os.getenv("FLASK_ENV") == "production":

--- a/app/ro_crates/routes/__init__.py
+++ b/app/ro_crates/routes/__init__.py
@@ -7,9 +7,11 @@
 from apiflask import APIBlueprint
 
 from app.ro_crates.routes.post_routes import post_routes_bp
+from app.ro_crates.routes.get_routes import get_routes_bp
 
 #ro_crates_bp = APIBlueprint("ro_crates", __name__)
 
 #ro_crates_bp.register_blueprint(post_routes_bp, url_prefix="/post")
 
-ro_crates_bp = post_routes_bp
+ro_crates_post_bp = post_routes_bp
+ro_crates_get_bp = get_routes_bp

--- a/app/ro_crates/routes/__init__.py
+++ b/app/ro_crates/routes/__init__.py
@@ -4,10 +4,10 @@
 # License: MIT
 # Copyright (c) 2025 eScience Lab, The University of Manchester
 
-from flask import Blueprint
+from apiflask import APIBlueprint
 
 from app.ro_crates.routes.post_routes import post_routes_bp
 
-ro_crates_bp = Blueprint("ro_crates", __name__)
+ro_crates_bp = APIBlueprint("ro_crates", __name__)
 
 ro_crates_bp.register_blueprint(post_routes_bp, url_prefix="/post")

--- a/app/ro_crates/routes/__init__.py
+++ b/app/ro_crates/routes/__init__.py
@@ -8,6 +8,8 @@ from apiflask import APIBlueprint
 
 from app.ro_crates.routes.post_routes import post_routes_bp
 
-ro_crates_bp = APIBlueprint("ro_crates", __name__)
+#ro_crates_bp = APIBlueprint("ro_crates", __name__)
 
-ro_crates_bp.register_blueprint(post_routes_bp, url_prefix="/post")
+#ro_crates_bp.register_blueprint(post_routes_bp, url_prefix="/post")
+
+ro_crates_bp = post_routes_bp

--- a/app/ro_crates/routes/post_routes.py
+++ b/app/ro_crates/routes/post_routes.py
@@ -4,11 +4,12 @@
 # License: MIT
 # Copyright (c) 2025 eScience Lab, The University of Manchester
 
-from flask import Blueprint, request, Response
+from apiflask import APIBlueprint
+from flask import request, Response
 
 from app.services.validation_service import queue_ro_crate_validation_task
 
-post_routes_bp = Blueprint("post_routes", __name__)
+post_routes_bp = APIBlueprint("post_routes", __name__)
 
 
 @post_routes_bp.route("/validate_by_id", methods=["POST"])

--- a/app/ro_crates/routes/post_routes.py
+++ b/app/ro_crates/routes/post_routes.py
@@ -24,16 +24,19 @@ def validate_ro_crate_from_id(json_data) -> tuple[Response, int]:
     """
     Endpoint to validate an RO-Crate using its ID from MinIO.
 
-    Parameters:
-    - **crate_id**: The ID of the RO-Crate to validate. _Required_.
-    - **profile_name**: The profile name for validation. _Optional_.
-    - **webhook_url**: The webhook URL where validation results will be sent. _Required_.
+    Args:
+      crate_id:
+        The ID of the RO-Crate to validate. _Required_.
+      profile_name:
+        The profile name for validation. _Optional_.
+      webhook_url:
+        The webhook URL where validation results will be sent. _Required_.
 
     Returns:
-    - A tuple containing the validation task's response and an HTTP status code.
+      A tuple containing the validation task's response and an HTTP status code.
 
     Raises:
-    - KeyError: If required parameters (`crate_id` or `webhook_url`) are missing.
+      KeyError: If required parameters (`crate_id` or `webhook_url`) are missing.
     """
 
     try:

--- a/app/ro_crates/routes/post_routes.py
+++ b/app/ro_crates/routes/post_routes.py
@@ -22,13 +22,18 @@ class validate_data(Schema):
 @post_routes_bp.input(validate_data(partial=True), location='json')
 def validate_ro_crate_from_id(json_data) -> tuple[Response, int]:
     """
-    Endpoint to validate an RO-Crate using its ID from MinIO. Requires webhook_url.
+    Endpoint to validate an RO-Crate using its ID from MinIO.
 
-    :param crate_id: The ID of the RO-Crate to validate. Required.
-    :param profile_name: The profile name for validation. Optional.
-    :param webhook_url: The webhook URL where validation results will be sent. Required.
-    :return: A tuple containing the validation task's response and an HTTP status code.
-    :raises: KeyError: If required parameters (`crate_id` or `webhook_url`) are missing.
+    Parameters:
+    - **crate_id**: The ID of the RO-Crate to validate. _Required_.
+    - **profile_name**: The profile name for validation. _Optional_.
+    - **webhook_url**: The webhook URL where validation results will be sent. _Required_.
+
+    Returns:
+    - A tuple containing the validation task's response and an HTTP status code.
+
+    Raises:
+    - KeyError: If required parameters (`crate_id` or `webhook_url`) are missing.
     """
 
     try:
@@ -38,7 +43,7 @@ def validate_ro_crate_from_id(json_data) -> tuple[Response, int]:
     try:
         webhook_url = json_data["webhook_url"]
     except:
-       raise KeyError("Missing required parameter: 'webhook_url'")
+        raise KeyError("Missing required parameter: 'webhook_url'")
 
     try:
         profile_name = json_data["profile_name"]
@@ -51,12 +56,17 @@ def validate_ro_crate_from_id(json_data) -> tuple[Response, int]:
 @post_routes_bp.input(validate_data(partial=True), location='json') # -> json_data
 def validate_ro_crate_from_id_no_webhook(json_data) -> tuple[Response, int]:
     """
-    Endpoint to validate an RO-Crate using its ID from MinIO. Does not require webhook_url.
+    Endpoint to validate an RO-Crate using its ID from MinIO.
 
-    :param crate_id: The ID of the RO-Crate to validate. Required.
-    :param profile_name: The profile name for validation. Optional.
-    :return: A tuple containing the validation task's response and an HTTP status code.
-    :raises: KeyError: If required parameters (`crate_id`) are missing.
+    Parameters:
+    - **crate_id**: The ID of the RO-Crate to validate. _Required_.
+    - **profile_name**: The profile name for validation. _Optional_.
+
+    Returns:
+    - A tuple containing the validation task's response and an HTTP status code.
+
+    Raises:
+    - KeyError: If required parameters (`crate_id`) are missing.
     """
 
     try:

--- a/app/services/validation_service.py
+++ b/app/services/validation_service.py
@@ -8,7 +8,10 @@ import logging
 
 from flask import jsonify, Response
 
-from app.tasks.validation_tasks import process_validation_task_by_id
+from app.tasks.validation_tasks import (
+    process_validation_task_by_id,
+    return_ro_crate_validation
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -37,3 +40,24 @@ def queue_ro_crate_validation_task(
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+def get_ro_crate_validation_task(
+    crate_id
+) -> tuple[Response, int]:
+    """
+    Retrieves an RO-Crate validation result.
+
+    :param crate_id: The ID of the RO-Crate to validate.
+    :return: A tuple containing a JSON response and an HTTP status code.
+    :raises Exception: If an error occurs whilst retrieving RO-Crate
+    """
+    logging.info(f"Retrieving validation for: {crate_id}")
+
+    if not crate_id:
+        return jsonify({"error": "Missing required parameter: crate_id"}), 400
+
+    try:
+        return return_ro_crate_validation(crate_id), 200
+    except Exception as e:
+        return jsonify({"service error": str(e)}), 500

--- a/app/tasks/validation_tasks.py
+++ b/app/tasks/validation_tasks.py
@@ -14,6 +14,7 @@ from app.celery_worker import celery
 from app.utils.minio_utils import (
     fetch_ro_crate_from_minio,
     update_validation_status_in_minio,
+    get_validation_status_from_minio
 )
 from app.utils.webhook_utils import send_webhook_notification
 
@@ -110,4 +111,25 @@ def perform_ro_crate_validation(
 
     except Exception as e:
         logging.error(f"Unexpected error during validation: {e}")
+        return str(e)
+
+
+def return_ro_crate_validation(
+    crate_id: str,
+) -> dict | str:
+    """
+    Retrieves the validation result for an RO-Crate using the provided Crate ID.
+
+    :param crate_id: The ID of the RO-Crate that has been validated
+    :return: The validation result
+    :raises Exception: If an error occurs in the retrieving the validation result
+    """
+
+    try:
+        logging.info(f"Fetching validation result for RO-Crate {crate_id}")
+
+        return get_validation_status_from_minio(crate_id)
+
+    except Exception as e:
+        logging.error(f"Unexpected error when retrieving validation: {e}")
         return str(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask~=3.0.3
 Werkzeug~=3.0.4
 redis~=5.2.0
 python-dotenv~=1.0.1
+apiflask~=2.4.0


### PR DESCRIPTION
This is an extension of the API to accomodate a GET call to retrieve the validation results.

Currently we don't handle (nicely) any requests which look for the validation of a non-existant RO-Crate. 

More development work:
- [ ] Check RO-Crates on MinIO, and make sure the named crate exists
- [ ] Check for the existence of a validation result for the named crate (or fail more nicely if this doesn't exist)
- [ ] Can we note if validation has been requested and is on-going? What would be best method to do this (placeholder file on MinIO?)
- [ ] Check dates of RO-Crate and validation result - make sure the result is younger than the RO-Crate. Alternatively we note the RO-Crate object (MinIO) version in the validation result file, so that this can be checked to make sure the validation result is up to date. 