### PR TITLE
build container and deploy to ghpackages on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 #
 name: Create and publish a Docker image
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
+# Configures this workflow to run every time a tagged release is created.
 on:
   release:
     types: [published]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ app/
 
       ![Validate MinIO versioning is enabled](docs/assets/validate-minio-versioning-enabled.webp "Validate MinIO versioning is enabled")
 
+
+## Development
+
+For standard usage the Docker Compose script uses prebuilt containers.
+For testing locally developed containers use the alternate Docker Compose file:
+```bash
+   docker compose --file docker-compose-develop.yml build
+   docker compose --file docker-compose-develop.yml up
+``` 
+
 ## Example Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ app/
 
 3. Build and start the services using Docker Compose:
     ```bash
-   docker compose build
-   docker compose up
+   docker compose up --build
    ```
 
 4. Set up the MinIO bucket
@@ -66,8 +65,7 @@ app/
 For standard usage the Docker Compose script uses prebuilt containers.
 For testing locally developed containers use the alternate Docker Compose file:
 ```bash
-   docker compose --file docker-compose-develop.yml build
-   docker compose --file docker-compose-develop.yml up
+   docker compose --file docker-compose-develop.yml up --build
 ``` 
 
 ## Example Usage

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -1,0 +1,55 @@
+version: '3.8'
+
+services:
+  flask:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5001:5000"
+    environment:
+      - FLASK_APP=cratey.py
+      - FLASK_ENV=development
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT}
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+    depends_on:
+      - redis
+      - minio
+
+  celery_worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT}
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+    depends_on:
+      - redis
+      - minio
+
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"
+
+  minio:
+    image: "minio/minio"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+      - MINIO_BROWSER_REDIRECT_PORT=9001
+    command: server --console-address ":9001" /data
+    volumes:
+      - minio_data:/data
+
+volumes:
+  minio_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   flask:
-    image: "ghcr.io/esciencelab/cratey-validator:pr-47"
+    image: "ghcr.io/esciencelab/cratey-validator:latest"
     ports:
       - "5001:5000"
     environment:
@@ -18,7 +18,7 @@ services:
       - minio
 
   celery_worker:
-    image: "ghcr.io/esciencelab/cratey-validator:pr-47"
+    image: "ghcr.io/esciencelab/cratey-validator:latest"
     command: celery -A app.celery_worker.celery worker --loglevel=info -E
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.8'
 
 services:
   flask:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: "ghcr.io/esciencelab/cratey-validator:pr-47"
     ports:
       - "5001:5000"
     environment:
@@ -20,9 +18,7 @@ services:
       - minio
 
   celery_worker:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: "ghcr.io/esciencelab/cratey-validator:pr-47"
     command: celery -A app.celery_worker.celery worker --loglevel=info -E
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0


### PR DESCRIPTION
This workflow will build the container only when a tagged release is made.

I've also modified the docker compose script to use these built containers, while retaining the original docker compose file as a development script. The README has been amended to reflect this.

Currently the docker compose is set to use the 'latest' tagged release - but we can change this when merging our release candidate into main.