### PR TITLE
Move minio credentials into api argument

### DIFF
--- a/app/ro_crates/routes/post_routes.py
+++ b/app/ro_crates/routes/post_routes.py
@@ -5,7 +5,8 @@
 # Copyright (c) 2025 eScience Lab, The University of Manchester
 
 from apiflask import APIBlueprint, Schema
-from apiflask.fields import String
+from apiflask.fields import String, Boolean
+from marshmallow.fields import Nested
 from flask import Response
 
 from app.services.validation_service import (
@@ -16,8 +17,16 @@ from app.services.validation_service import (
 post_routes_bp = APIBlueprint("post_routes", __name__)
 
 
+class MinioConfig(Schema):
+    endpoint = String(required=True)
+    accesskey = String(required=True)
+    secret = String(required=True)
+    ssl = Boolean(required=True)
+    bucket = String(required=True)
+
+
 class ValidateCrate(Schema):
-    minio_bucket = String(required=True)
+    minio_config = Nested(MinioConfig, required=True)
     root_path = String(required=False)
     profile_name = String(required=False)
     webhook_url = String(required=False)
@@ -38,7 +47,12 @@ def validate_ro_crate_via_id(json_data, crate_id) -> tuple[Response, int]:
     - **crate_id**: The RO-Crate ID. _Required_.
 
     Request Body Parameters:
-    - **minio_bucket**: The MinIO bucket containing the RO-Crate. _Required_
+    - **minio_config**: The MinIO bucket containing the RO-Crate. _Required_
+      - **endpoint**: Endpoint, e.g. 'localhost:9000'
+      - **accesskey**: Access key / username
+      - **secret**: Secret / password
+      - **ssl**: Use SSL encryption? True/False
+      - **bucket**: The MinIO bucket to access 
     - **root_path**: The root path containing the RO-Crate. _Optional_
     - **profile_name**: The profile name for validation. _Optional_.
     - **webhook_url**: The webhook URL where validation results will be sent. _Optional_.
@@ -50,7 +64,7 @@ def validate_ro_crate_via_id(json_data, crate_id) -> tuple[Response, int]:
     - KeyError: If required parameters (`crate_id` or `webhook_url`) are missing.
     """
 
-    minio_bucket = json_data["minio_bucket"]
+    minio_config = json_data["minio_config"]
 
     if "root_path" in json_data:
         root_path = json_data["root_path"]
@@ -67,7 +81,7 @@ def validate_ro_crate_via_id(json_data, crate_id) -> tuple[Response, int]:
     else:
         profile_name = None
 
-    return queue_ro_crate_validation_task(minio_bucket, crate_id, root_path, profile_name, webhook_url)
+    return queue_ro_crate_validation_task(minio_config, crate_id, root_path, profile_name, webhook_url)
 
 
 @post_routes_bp.post("/validate_metadata")

--- a/app/services/validation_service.py
+++ b/app/services/validation_service.py
@@ -100,14 +100,14 @@ def queue_ro_crate_metadata_validation_task(
 
 
 def get_ro_crate_validation_task(
-    minio_bucket: str,
+    minio_config: dict,
     crate_id: str,
     root_path: str,
 ) -> tuple[Response, int]:
     """
     Retrieves an RO-Crate validation result.
 
-    :param minio_bucket: The MinIO bucket containing the RO-Crate.
+    :param minio_config: Access settings for Minio instance containing the RO-Crate.
     :param crate_id: The ID of the RO-Crate to validate.
     :param root_path: The root path containing the RO-Crate.
     :return: A tuple containing a JSON response and an HTTP status code.
@@ -115,16 +115,18 @@ def get_ro_crate_validation_task(
     """
     logging.info(f"Retrieving validation for: {crate_id}")
 
-    if check_ro_crate_exists(minio_bucket, crate_id, root_path):
+    minio_client = get_minio_client(minio_config)
+
+    if check_ro_crate_exists(minio_client, minio_config["bucket"], crate_id, root_path):
         logging.info("RO-Crate exists")
     else:
         logging.info("RO-Crate does not exist")
         raise InvalidAPIUsage(f"No RO-Crate with prefix: {crate_id}", 400)
 
-    if check_validation_exists(minio_bucket, crate_id, root_path):
+    if check_validation_exists(minio_client, minio_config["bucket"], crate_id, root_path):
         logging.info("Validation result exists")
     else:
         logging.info("Validation does not exist")
         raise InvalidAPIUsage(f"No validation result yet for RO-Crate: {crate_id}", 400)
 
-    return return_ro_crate_validation(minio_bucket, crate_id, root_path), 200
+    return return_ro_crate_validation(minio_client, minio_config["bucket"], crate_id, root_path), 200

--- a/app/tasks/validation_tasks.py
+++ b/app/tasks/validation_tasks.py
@@ -242,6 +242,7 @@ def check_validation_exists(
 
 
 def return_ro_crate_validation(
+        minio_client: object,
         bucket_name: str,
         crate_id: str,
         root_path: str,
@@ -249,10 +250,11 @@ def return_ro_crate_validation(
     """
     Retrieves the validation result for an RO-Crate using the provided Crate ID.
 
+    :param minio_client: The MinIO client
     :param crate_id: The ID of the RO-Crate that has been validated
     :return: The validation result
     """
 
     logging.info(f"Fetching validation result for RO-Crate {crate_id}")
 
-    return get_validation_status_from_minio(bucket_name, crate_id, root_path)
+    return get_validation_status_from_minio(minio_client, bucket_name, crate_id, root_path)

--- a/app/tasks/validation_tasks.py
+++ b/app/tasks/validation_tasks.py
@@ -216,6 +216,7 @@ def check_ro_crate_exists(
 
 
 def check_validation_exists(
+        minio_client: object,
         bucket_name: str,
         crate_id: str,
         root_path: str,
@@ -223,6 +224,7 @@ def check_validation_exists(
     """
     Checks for the existence of a validation result using the provided Crate ID.
 
+    :param minio_client: The MinIO client
     :param minio_bucket: The MinIO bucket containing the RO-Crate.
     :param crate_id: The ID of the RO-Crate to validate.
     :param root_path: The root path containing the RO-Crate.
@@ -231,7 +233,6 @@ def check_validation_exists(
 
     logging.info(f"Checking for existence of RO-Crate {crate_id}")
 
-    minio_client = get_minio_client()
     if find_validation_object_on_minio(crate_id, minio_client, bucket_name, root_path):
         return True
     else:

--- a/app/tasks/validation_tasks.py
+++ b/app/tasks/validation_tasks.py
@@ -192,6 +192,7 @@ def perform_ro_crate_validation(
 
 
 def check_ro_crate_exists(
+        minio_client: object,
         bucket_name: str,
         crate_id: str,
         root_path: str,
@@ -199,7 +200,8 @@ def check_ro_crate_exists(
     """
     Checks for the existence of an RO-Crate using the provided Crate ID.
 
-    :param minio_bucket: The MinIO bucket containing the RO-Crate.
+    :param minio_client: The MinIO client
+    :param bucket_name: The MinIO bucket containing the RO-Crate.
     :param crate_id: The ID of the RO-Crate to validate.
     :param root_path: The root path containing the RO-Crate.
     :return: Boolean indicating existence
@@ -207,7 +209,6 @@ def check_ro_crate_exists(
 
     logging.info(f"Checking for existence of RO-Crate {crate_id}")
 
-    minio_client = get_minio_client()
     if find_rocrate_object_on_minio(crate_id, minio_client, bucket_name, root_path):
         return True
     else:

--- a/app/utils/minio_utils.py
+++ b/app/utils/minio_utils.py
@@ -109,11 +109,12 @@ def update_validation_status_in_minio(minio_client: object, minio_bucket: str, c
     )
 
 
-def get_validation_status_from_minio(minio_bucket: str, crate_id: str, root_path: str) -> dict:
+def get_validation_status_from_minio(minio_client: object, minio_bucket: str, crate_id: str, root_path: str) -> dict:
     """
     Checks for the existence of a validation report for the given RO-Crate in the MinIO bucket.
     Returns validation message if it exists, or notification that it is missing if not.
 
+    :param minio_client: The MinIO client
     :param minio_bucket: The MinIO bucket containing the RO-Crate.
     :param crate_id: The ID of the RO-Crate in MinIO
     :return validation_status: Either the validation status, or note that this does not exist
@@ -129,9 +130,6 @@ def get_validation_status_from_minio(minio_bucket: str, crate_id: str, root_path
     logging.info(f"Getting object {object_name}")
 
     try:
-
-        minio_client = get_minio_client()
-
         response = minio_client.get_object(
             minio_bucket,
             object_name,

--- a/app/utils/minio_utils.py
+++ b/app/utils/minio_utils.py
@@ -61,10 +61,11 @@ def fetch_ro_crate_from_minio(minio_client: object, minio_bucket: str, crate_id:
     return local_root_path
 
 
-def update_validation_status_in_minio(minio_bucket: str, crate_id: str, root_path: str, validation_status: str) -> None:
+def update_validation_status_in_minio(minio_client: object, minio_bucket: str, crate_id: str, root_path: str, validation_status: str) -> None:
     """
     Uploads the validation status to the MinIO bucket.
 
+    :param minio_client: The MinIO client
     :param minio_bucket: The MinIO bucket containing the RO-Crate.
     :param crate_id: The ID of the RO-Crate in MinIO
     :param validation_status: The validation result to upload
@@ -83,9 +84,6 @@ def update_validation_status_in_minio(minio_bucket: str, crate_id: str, root_pat
     validation_string = json.dumps(json.loads(validation_status), indent=None).encode("utf-8")
 
     try:
-
-        minio_client = get_minio_client()
-
         minio_client.put_object(
             minio_bucket,
             object_name,

--- a/app/utils/minio_utils.py
+++ b/app/utils/minio_utils.py
@@ -17,17 +17,16 @@ from app.utils.config import InvalidAPIUsage
 logger = logging.getLogger(__name__)
 
 
-def fetch_ro_crate_from_minio(minio_bucket: str, crate_id: str, root_path: str) -> str:
+def fetch_ro_crate_from_minio(minio_client: object, minio_bucket: str, crate_id: str, root_path: str) -> str:
     """
     Fetches an RO-Crate from MinIO based on the crate ID. Downloads the crate as a file and returns local file path.
 
+    :param minio_client: The MinIO client
     :param minio_bucket: The MinIO bucket containing the RO-Crate.
     :param crate_id: The ID of the RO-Crate to fetch from MinIO.
     :param root_path: The root path containing the RO-Crate.
     :return: The local file path where the RO-Crate is saved.
     """
-
-    minio_client = get_minio_client()
 
     rocrate_object = find_rocrate_object_on_minio(crate_id, minio_client, minio_bucket, root_path)
 

--- a/app/utils/minio_utils.py
+++ b/app/utils/minio_utils.py
@@ -9,7 +9,6 @@ import logging
 import os
 import tempfile
 
-from dotenv import load_dotenv
 from io import BytesIO
 from minio import Minio, S3Error
 from app.utils.config import InvalidAPIUsage
@@ -306,20 +305,24 @@ def get_minio_object_list(object_path: str, minio_client, minio_bucket: str, rec
         return object_list
 
 
-def get_minio_client() -> Minio:
+def get_minio_client(minio_config: dict) -> Minio:
     """
-    Initialises the MinIO client from environment variables.
+    Initialises the MinIO client from provided settings.
 
+    :param minio_config: A dictionary containing the below parameters
+    :param endpoint: A string containing host and port. E.g. 'localhost:9000'
+    :param access_key: A string containing the access key / username
+    :param secret_key: A string containing the secret key / password
+    :param use_ssl: Boolean defining if SSL connection should be used or not
     :return: The MinIO client.
     :raises ValueError: If required environment variables are not set.
     """
-    load_dotenv()
 
     minio_client = Minio(
-        endpoint=os.environ.get("MINIO_ENDPOINT"),
-        access_key=os.environ.get("MINIO_ROOT_USER"),
-        secret_key=os.environ.get("MINIO_ROOT_PASSWORD"),
-        secure=False,
+        endpoint=minio_config["endpoint"],
+        access_key=minio_config["accesskey"],
+        secret_key=minio_config["secret"],
+        secure=minio_config["ssl"],
     )
 
     return minio_client

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -17,7 +17,13 @@ def client():
         [
             (
                 "crate-123", {
-                    "minio_bucket": "test_bucket",
+                    "minio_config": {
+                        "endpoint": "localhost:9000",
+                        "accesskey": "admin",
+                        "secret": "password123",
+                        "ssl": False,
+                        "bucket": "test_bucket"
+                    },
                     "root_path": "base_path",
                     "webhook_url": "https://webhook.example.com",
                     "profile_name": "default"
@@ -25,28 +31,52 @@ def client():
             ),
             (
                 "crate-123", {
-                    "minio_bucket": "test_bucket",
-                    "root_path": "base_path",
+                    "minio_config": {
+                        "endpoint": "localhost:9000",
+                        "accesskey": "admin",
+                        "secret": "password123",
+                        "ssl": False,
+                        "bucket": "test_bucket"
+                    },
+                     "root_path": "base_path",
                     "webhook_url": "https://webhook.example.com",
                 }, 202, {"message": "Validation in progress"}
             ),
             (
                 "crate-123", {
-                    "minio_bucket": "test_bucket",
-                    "root_path": "base_path",
+                    "minio_config": {
+                        "endpoint": "localhost:9000",
+                        "accesskey": "admin",
+                        "secret": "password123",
+                        "ssl": False,
+                        "bucket": "test_bucket"
+                    },
+                     "root_path": "base_path",
                     "profile_name": "default"
                 }, 202, {"message": "Validation in progress"}
             ),
             (
                 "crate-123", {
-                    "minio_bucket": "test_bucket",
+                    "minio_config": {
+                        "endpoint": "localhost:9000",
+                        "accesskey": "admin",
+                        "secret": "password123",
+                        "ssl": False,
+                        "bucket": "test_bucket"
+                    },
                     "webhook_url": "https://webhook.example.com",
                     "profile_name": "default"
                 }, 202, {"message": "Validation in progress"}
             ),
             (
                 "crate-123", {
-                    "minio_bucket": "test_bucket"
+                    "minio_config": {
+                        "endpoint": "localhost:9000",
+                        "accesskey": "admin",
+                        "secret": "password123",
+                        "ssl": False,
+                        "bucket": "test_bucket"
+                    },
                 }, 202, {"message": "Validation in progress"}
             ),
         ],
@@ -60,13 +90,13 @@ def test_validate_by_id_success(client: FlaskClient, crate_id: str, payload: dic
 
         response = client.post(f"/v1/ro_crates/{crate_id}/validation", json=payload)
 
-        minio_bucket = payload["minio_bucket"] if "minio_bucket" in payload else None
+        minio_config = payload["minio_config"] if "minio_config" in payload else None
         root_path = payload["root_path"] if "root_path" in payload else None
         profile_name = payload["profile_name"] if "profile_name" in payload else None
         webhook_url = payload["webhook_url"] if "webhook_url" in payload else None
         assert response.status_code == status_code
         assert response.json == response_json
-        mock_queue.assert_called_once_with(minio_bucket, crate_id, root_path, profile_name, webhook_url)
+        mock_queue.assert_called_once_with(minio_config, crate_id, root_path, profile_name, webhook_url)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -104,7 +104,13 @@ def test_no_rocrate_for_validation():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates"
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        }
     }
 
     response = requests.post(url, json=payload, headers=headers)
@@ -130,7 +136,13 @@ def test_no_validation_result_for_missing_crate():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates"
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        }
     }
 
     # GET action and tests
@@ -156,7 +168,13 @@ def test_get_existing_validation_result():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates"
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        }
     }
 
     # GET action and tests
@@ -182,7 +200,13 @@ def test_rocrate_not_validated_yet():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates"
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        }
     }
 
     # GET action and tests
@@ -209,7 +233,13 @@ def test_zipped_rocrate_validation():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates"
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        }
     }
 
     # POST action and tests
@@ -266,7 +296,13 @@ def test_directory_rocrate_validation():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates"
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        }
     }
 
     # POST action and tests
@@ -322,7 +358,13 @@ def test_ignore_rocrates_not_on_basepath():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates"
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        }
     }
 
     # POST action and tests
@@ -350,7 +392,13 @@ def test_zipped_rocrate_in_subdirectory_validation():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates",
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        },
         "root_path" : subdir_path
     }
 
@@ -409,7 +457,13 @@ def test_directory_rocrate_in_subdirectory_validation():
 
     # The API expects the JSON to be passed as a string
     payload = {
-        "minio_bucket" : "ro-crates",
+        "minio_config": {
+            "endpoint": "minio:9000",
+            "accesskey": "minioadmin",
+            "secret": "minioadmin",
+            "ssl": False,
+            "bucket": "ro-crates"
+        },
         "root_path" : subdir_path
     }
 

--- a/tests/test_minio.py
+++ b/tests/test_minio.py
@@ -22,14 +22,29 @@ class DummyObject:
 
 # Testing function: get_minio_client
 
-def test_get_minio_client_success(monkeypatch):
-    # Set required env vars
-    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
-    monkeypatch.setenv("MINIO_ROOT_USER", "admin")
-    monkeypatch.setenv("MINIO_ROOT_PASSWORD", "password123")
+@pytest.mark.parametrize(
+        "minio_config",
+        [
+            {
+                "endpoint": "localhost:9000",
+                "accesskey": "admin",
+                "secret": "password123",
+                "ssl": False
+            },
+            {
+                "endpoint": "localhost:9000",
+                "accesskey": "admin",
+                "secret": "password123",
+                "ssl": False,
+                "bucket": "ignore_this"
+            }
+        ],
+        ids=["base_case", "ignore_extra_items"]
+)
+def test_get_minio_client_success(minio_config: dict):
 
     from app.utils.minio_utils import get_minio_client
-    client = get_minio_client()
+    client = get_minio_client(minio_config)
 
     assert isinstance(client, Minio)
     assert client._base_url.host == "localhost:9000"

--- a/tests/test_minio.py
+++ b/tests/test_minio.py
@@ -423,16 +423,14 @@ def test_update_validation_status_erro(
 @patch("app.utils.minio_utils.download_file_from_minio")
 @patch("app.utils.minio_utils.get_minio_object_list")
 @patch("app.utils.minio_utils.find_rocrate_object_on_minio")
-@patch("app.utils.minio_utils.get_minio_client")
 def test_fetch_rocrate_zip(
-    mock_get_client,
     mock_find_object,
     mock_get_list,
     mock_download,
     tmp_path,
 ):
     # Setup mocks
-    mock_get_client.return_value = "minio_client"
+    minio_client = "minio_client"
     rocrate_obj = DummyObject("some/path/rocrate123.zip", is_dir=False)
     mock_find_object.return_value = rocrate_obj
 
@@ -440,7 +438,7 @@ def test_fetch_rocrate_zip(
 
     with patch("app.utils.minio_utils.tempfile.mkdtemp", return_value=str(tmp_path)):
         # Execute
-        result = fetch_ro_crate_from_minio("test_bucket", "rocrate123", "some/path")
+        result = fetch_ro_crate_from_minio(minio_client, "test_bucket", "rocrate123", "some/path")
 
     # Assert
     expected_path = tmp_path / "rocrate123.zip"
@@ -453,16 +451,14 @@ def test_fetch_rocrate_zip(
 @patch("app.utils.minio_utils.download_file_from_minio")
 @patch("app.utils.minio_utils.get_minio_object_list")
 @patch("app.utils.minio_utils.find_rocrate_object_on_minio")
-@patch("app.utils.minio_utils.get_minio_client")
 def test_fetch_rocrate_directory(
-    mock_get_client,
     mock_find_object,
     mock_get_list,
     mock_download,
     tmp_path,
 ):
     # Setup mocks
-    mock_get_client.return_value = "minio_client"
+    minio_client = "minio_client"
     rocrate_obj = DummyObject("rocrates/rocrate124", is_dir=True)
     mock_find_object.return_value = rocrate_obj
 
@@ -476,7 +472,7 @@ def test_fetch_rocrate_directory(
         ]
 
         # Execute
-        result = fetch_ro_crate_from_minio("test_bucket", "rocrate124", "rocrates")
+        result = fetch_ro_crate_from_minio(minio_client, "test_bucket", "rocrate124", "rocrates")
 
         # Assert
         expected_root = tmp_path / "rocrate124"
@@ -496,15 +492,13 @@ def test_fetch_rocrate_directory(
 @patch("app.utils.minio_utils.download_file_from_minio")
 @patch("app.utils.minio_utils.get_minio_object_list")
 @patch("app.utils.minio_utils.find_rocrate_object_on_minio")
-@patch("app.utils.minio_utils.get_minio_client")
 def test_fetch_rocrate_handles_empty_dir(
-    mock_get_client,
     mock_find_object,
     mock_get_list,
     mock_download,
     tmp_path,
 ):
-    mock_get_client.return_value = "minio_client"
+    minio_client = "minio_client"
     rocrate_obj = DummyObject("rocrate456", is_dir=True)
     mock_find_object.return_value = rocrate_obj
     mock_get_list.return_value = []
@@ -512,7 +506,7 @@ def test_fetch_rocrate_handles_empty_dir(
     from app.utils.minio_utils import fetch_ro_crate_from_minio
 
     with patch("app.utils.minio_utils.tempfile.mkdtemp", return_value=str(tmp_path)):
-        result = fetch_ro_crate_from_minio("test_bucket", "rocrate456", "")
+        result = fetch_ro_crate_from_minio(minio_client, "test_bucket", "rocrate456", "")
 
         expected_root = tmp_path / "rocrate456"
         assert result == str(expected_root)

--- a/tests/test_minio.py
+++ b/tests/test_minio.py
@@ -283,10 +283,9 @@ def test_download_s3error(
 def test_successful_retrieval(mocker, mock_minio_response):
     mock_client = MagicMock()
     mock_client.get_object.return_value = mock_minio_response
-    mocker.patch("app.utils.minio_utils.get_minio_client", return_value=mock_client)
 
     from app.utils.minio_utils import get_validation_status_from_minio
-    result = get_validation_status_from_minio("test_bucket", "crate123", None)
+    result = get_validation_status_from_minio(mock_client, "test_bucket", "crate123", None)
 
     assert result == {"status": "valid"}
     mock_minio_response.close.assert_called_once()
@@ -325,11 +324,10 @@ def test_get_validation_error_raised(
 ):
     mock_client = MagicMock()
     mock_client.get_object.side_effect = get_side_effect
-    mocker.patch("app.utils.minio_utils.get_minio_client", return_value=mock_client)
 
     from app.utils.minio_utils import get_validation_status_from_minio, InvalidAPIUsage
     with pytest.raises(InvalidAPIUsage) as exc:
-        get_validation_status_from_minio(bucket, crateid, root_path)
+        get_validation_status_from_minio(mock_client, bucket, crateid, root_path)
 
     assert exc.value.status_code == status_code
     assert error_check in str(exc.value.message)

--- a/tests/test_validation_tasks.py
+++ b/tests/test_validation_tasks.py
@@ -385,10 +385,10 @@ def test_return_validation_returns_dict(mock_get_status):
     # Simulate dict result
     mock_get_status.return_value = {"status": "passed", "errors": []}
 
-    result = return_ro_crate_validation("test_bucket", "crate123", None)
+    result = return_ro_crate_validation("minio_client", "test_bucket", "crate123", None)
     assert isinstance(result, dict)
     assert result["status"] == "passed"
-    mock_get_status.assert_called_once_with("test_bucket", "crate123", None)
+    mock_get_status.assert_called_once_with("minio_client", "test_bucket", "crate123", None)
 
 
 @mock.patch("app.tasks.validation_tasks.get_validation_status_from_minio")
@@ -396,10 +396,10 @@ def test_return_validation_returns_string(mock_get_status):
     # Simulate string result
     mock_get_status.return_value = "Validation result: OK"
 
-    result = return_ro_crate_validation("test_bucket", "crate456", None)
+    result = return_ro_crate_validation("minio_client", "test_bucket", "crate456", None)
     assert isinstance(result, str)
     assert "OK" in result
-    mock_get_status.assert_called_once_with("test_bucket", "crate456", None)
+    mock_get_status.assert_called_once_with("minio_client", "test_bucket", "crate456", None)
 
 
 @mock.patch("app.tasks.validation_tasks.get_validation_status_from_minio")
@@ -408,10 +408,10 @@ def test_return_validation_raises_error(mock_get_status):
     mock_get_status.side_effect = InvalidAPIUsage("MinIO S3 Error: empty", 500)
 
     with pytest.raises(InvalidAPIUsage) as exc_info:
-        return_ro_crate_validation("test_bucket", "crate789", None)
+        return_ro_crate_validation("minio_client", "test_bucket", "crate789", None)
 
     assert "MinIO S3 Error" in str(exc_info.value.message)
-    mock_get_status.assert_called_once_with("test_bucket", "crate789", None)
+    mock_get_status.assert_called_once_with("minio_client", "test_bucket", "crate789", None)
 
 
 # Test function: check_ro_crate_exists

--- a/tests/test_validation_tasks.py
+++ b/tests/test_validation_tasks.py
@@ -349,17 +349,17 @@ def test_return_validation_raises_error(mock_get_status):
 # Test function: check_ro_crate_exists
 
 @pytest.mark.parametrize(
-        "minio_client, bucket, crate_id, base_path, client_return, ro_object_return, rocrate_exists",
+        "minio_client, bucket, crate_id, base_path, ro_object_return, rocrate_exists",
         [
-            ("minio_client", "test_bucket", "crate123", "base_path", "mock_client", "crate123", True),
-            ("minio_client", "test_bucket", "crate12z", "base_path", "mock_client", False, False)
+            ("minio_client", "test_bucket", "crate123", "base_path", "crate123", True),
+            ("minio_client", "test_bucket", "crate12z", "base_path", False, False)
         ],
         ids=["rocrate_exists", "rocrate_does_not_exist"]
 )
 @mock.patch("app.tasks.validation_tasks.find_rocrate_object_on_minio")
 def test_ro_crate_exists(
     mock_find_rocrate,
-    minio_client: str, bucket: str, crate_id: str, base_path: str, client_return: str,
+    minio_client: str, bucket: str, crate_id: str, base_path: str,
     ro_object_return: str, rocrate_exists: bool
 ):
     mock_find_rocrate.return_value = ro_object_return
@@ -373,26 +373,22 @@ def test_ro_crate_exists(
 # Test function: check_validation_exists
 
 @pytest.mark.parametrize(
-        "bucket, crate_id, base_path, client_return, val_object_return, validate_exists",
+        "minio_client, bucket, crate_id, base_path, val_object_return, validate_exists",
         [
-            ("test_bucket", "crate123", "base_path", "mock_client", "crate123", True),
-            ("test_bucket", "crate12z", "base_path", "mock_client", False, False)
+            ("minio_client", "test_bucket", "crate123", "base_path", "crate123", True),
+            ("minio_client", "test_bucket", "crate12z", "base_path", False, False)
         ],
         ids=["validation_exists", "validation_does_not_exist"]
 )
-@mock.patch("app.tasks.validation_tasks.get_minio_client")
 @mock.patch("app.tasks.validation_tasks.find_validation_object_on_minio")
 def test_validation_exists(
     mock_find_validation,
-    mock_get_client,
-    bucket: str, crate_id: str, base_path: str, client_return: str,
+    minio_client: str, bucket: str, crate_id: str, base_path: str,
     val_object_return: str, validate_exists: bool
 ):
-    mock_get_client.return_value = client_return
     mock_find_validation.return_value = val_object_return
 
-    result = check_validation_exists(bucket, crate_id, base_path)
+    result = check_validation_exists(minio_client, bucket, crate_id, base_path)
 
-    mock_get_client.assert_called_once()
-    mock_find_validation.assert_called_once_with(crate_id, client_return, bucket, base_path)
+    mock_find_validation.assert_called_once_with(crate_id, minio_client, bucket, base_path)
     assert result is validate_exists

--- a/tests/test_validation_tasks.py
+++ b/tests/test_validation_tasks.py
@@ -349,28 +349,24 @@ def test_return_validation_raises_error(mock_get_status):
 # Test function: check_ro_crate_exists
 
 @pytest.mark.parametrize(
-        "bucket, crate_id, base_path, client_return, ro_object_return, rocrate_exists",
+        "minio_client, bucket, crate_id, base_path, client_return, ro_object_return, rocrate_exists",
         [
-            ("test_bucket", "crate123", "base_path", "mock_client", "crate123", True),
-            ("test_bucket", "crate12z", "base_path", "mock_client", False, False)
+            ("minio_client", "test_bucket", "crate123", "base_path", "mock_client", "crate123", True),
+            ("minio_client", "test_bucket", "crate12z", "base_path", "mock_client", False, False)
         ],
         ids=["rocrate_exists", "rocrate_does_not_exist"]
 )
-@mock.patch("app.tasks.validation_tasks.get_minio_client")
 @mock.patch("app.tasks.validation_tasks.find_rocrate_object_on_minio")
 def test_ro_crate_exists(
     mock_find_rocrate,
-    mock_get_client,
-    bucket: str, crate_id: str, base_path: str, client_return: str,
+    minio_client: str, bucket: str, crate_id: str, base_path: str, client_return: str,
     ro_object_return: str, rocrate_exists: bool
 ):
-    mock_get_client.return_value = client_return
     mock_find_rocrate.return_value = ro_object_return
 
-    result = check_ro_crate_exists(bucket, crate_id, base_path)
+    result = check_ro_crate_exists(minio_client, bucket, crate_id, base_path)
 
-    mock_get_client.assert_called_once()
-    mock_find_rocrate.assert_called_once_with(crate_id, client_return, bucket, base_path)
+    mock_find_rocrate.assert_called_once_with(crate_id, minio_client, bucket, base_path)
     assert result is rocrate_exists
 
 


### PR DESCRIPTION
This PR does two things:

1. MinIO credentials are now passed in the API payloads
2. MinIO client is loaded higher up the stack, and passed to functions which need it, reducing the repetition of this activity.