### PR TITLE
docker project specified for local integration testing

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,6 +8,7 @@ import docker
 from minio import Minio
 import uuid
 
+
 @pytest.fixture(scope="session")
 def docker_client():
     return docker.from_env()


### PR DESCRIPTION
I'm using a unique docker project ID for each run of the integration testing (created using [uuid.uuid4](https://docs.python.org/3/library/uuid.html#uuid.uuid4) library, on the suggestion of chatgpt), so that running this locally will use a separate and unique volume instance for the tests. This is then deleted by docker compose down (using `-v` flag).