### PR TITLE
Fix `crate_json` quoting in README `validate_metadata` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ curl -X 'POST' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
- "crate_json": "{'\''test1'\'':'\''test2'\''}"
+ "crate_json": "{\"test1\":\"test2\"}"
  }'
 ```
 


### PR DESCRIPTION
The nested JSON should use `"` not `'`