### PR TITLE
chore(deps): bump requests to 2.34.2 and requests-cache to 1.3.3

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Keep in sync with requirements-dev.txt
-          pip install pytest==9.1.0 requests==2.33.1 boto3==1.43.29
+          pip install pytest==9.1.0 requests==2.34.2 boto3==1.43.29
 
       - name: Run integration tests (brings up the compose stack)
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [{ name = "eScience Lab, The University of Manchester" }]
 dependencies = [
     "celery==5.6.3",
     "boto3==1.43.29",
-    "requests==2.33.1",
+    "requests==2.34.2",
     "Flask==3.1.3",
     "Werkzeug==3.1.8",
     "redis==8.0.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,6 @@ apiflask==3.1.0
     # via ro-crate-validation-service (pyproject.toml)
 apispec==6.10.0
     # via apiflask
-async-timeout==5.0.1
-    # via redis
 attrs==26.1.0
     # via
     #   cattrs
@@ -187,14 +185,14 @@ rdflib[html]==7.6.0
     #   roc-validator
 redis==8.0.1
     # via ro-crate-validation-service (pyproject.toml)
-requests==2.33.1
+requests==2.34.2
     # via
     #   moto
     #   requests-cache
     #   responses
     #   ro-crate-validation-service (pyproject.toml)
     #   roc-validator
-requests-cache==1.3.2
+requests-cache==1.3.3
     # via roc-validator
 responses==0.26.1
     # via moto
@@ -223,8 +221,6 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-typos==1.47.2
-    # via roc-validator
 tzdata==2026.2
     # via kombu
 tzlocal==5.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ apiflask==3.1.0
     # via ro-crate-validation-service (pyproject.toml)
 apispec==6.8.2
     # via apiflask
-async-timeout==5.0.1
-    # via redis
 attrs==25.3.0
     # via
     #   cattrs
@@ -147,12 +145,12 @@ rdflib[html]==7.1.4
     #   roc-validator
 redis==8.0.1
     # via ro-crate-validation-service (pyproject.toml)
-requests==2.33.1
+requests==2.34.2
     # via
     #   requests-cache
     #   ro-crate-validation-service (pyproject.toml)
     #   roc-validator
-requests-cache==1.2.1
+requests-cache==1.3.3
     # via roc-validator
 rich==13.9.4
     # via
@@ -178,8 +176,6 @@ typing-extensions==4.14.1
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-typos==1.42.0
-    # via roc-validator
 tzdata==2025.2
     # via kombu
 tzlocal==5.3.1


### PR DESCRIPTION
- Supersedes #157 
- requests 2.34 made `RequestsCookieJar` a `TYPE_CHECKING`-only import in requests/models.py, which breaks requests-cache 1.2.1
- Dependabot's #157 bumped only requests and failed the docker build
- I also updated to drop async-timeout (redis only needs it on Python < 3.11.3) and typos (no longer required by roc-validator).