### PR TITLE
use latest image for example compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 services:
   flask:
     platform: linux/x86_64
-    image: "ghcr.io/esciencelab/ro-crate-validation-service:0.1"
+    image: "ghcr.io/esciencelab/ro-crate-validation-service:latest"
     ports:
       - "5001:5000"
     environment:
@@ -28,7 +28,7 @@ services:
 
   celery_worker:
     platform: linux/x86_64
-    image: "ghcr.io/esciencelab/ro-crate-validation-service:0.1"
+    image: "ghcr.io/esciencelab/ro-crate-validation-service:latest"
     command: celery -A app.celery_worker.celery worker --loglevel=info -E
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0


### PR DESCRIPTION
Although it is wise to use specific tags for images in deployment, to make sure that the example docker compose file can be run easily I think it's probably best to use the 'latest' tag.