### PR TITLE
GH workflows only trigger for relevant parts of the code base

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint
 on:
   pull_request:
     branches: [ develop ]
+    paths:
+      - app/**
+      - tests/**
 
 jobs:
   ruff:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - app/**
       - tests/**
+      - requirements*.txt
+      - pyproject.toml
+      - Dockerfile
+      - docker-compose*.yml
+      - .dockerignore
+      - example.env
+      - wsgi.py
 
 jobs:
   ruff:

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -3,6 +3,9 @@ name: Integration Tests
 on:
   pull_request:
     branches: [ develop ]
+    paths:
+      - app/**
+      - tests/**
 
 jobs:
   test:

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - app/**
       - tests/**
+      - requirements*.txt
+      - pyproject.toml
+      - Dockerfile
+      - docker-compose*.yml
+      - .dockerignore
+      - example.env
+      - wsgi.py
 
 jobs:
   test:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,6 +3,10 @@ name: Unit Tests
 on:
   pull_request:
     branches: [ develop ]
+    paths:
+      - app/**
+      - tests/**
+  
 
 jobs:
   test:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,13 @@ on:
     paths:
       - app/**
       - tests/**
-  
+      - requirements*.txt
+      - pyproject.toml
+      - Dockerfile
+      - docker-compose*.yml
+      - .dockerignore
+      - example.env
+      - wsgi.py
 
 jobs:
   test:


### PR DESCRIPTION
The unit test, integration test, and code linting workflows only run on changes to the `app` and `tests` directories:
```
on:
  pull_request:
    branches: [ develop ]
    paths:
      - app/**
      - tests/**
```